### PR TITLE
Refactor the browser page into separate files

### DIFF
--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -13,5 +13,11 @@
         <file>qml/NewTabPage.qml</file>
         <file>qml/ColorChooser.qml</file>
         <file>qml/TabBarItemDelegate.qml</file>
+        <file>qml/BrowserPage.qml</file>
+        <file>qml/BrowserTabBar.qml</file>
+        <file>qml/BrowserToolbar.qml</file>
+        <file>qml/BookmarksBar.qml</file>
+        <file>qml/FullscreenBar.qml</file>
+        <file>qml/Omnibox.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/BookmarksBar.qml
+++ b/src/qml/BookmarksBar.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Rectangle {
+    id: bookmarksBar
+
+    color: toolbar.color
+    height: visible ? Units.dp(48) : 0
+    width: parent.width
+
+    property alias bookmarkContainer: bookmarkContainer
+
+    Flickable {
+        anchors.fill: parent
+        anchors.margins: Units.dp(5)
+        anchors.leftMargin: Units.dp(24)
+        contentWidth: bookmarkContainer.implicitWidth + Units.dp(16)
+
+        Row {
+            id: bookmarkContainer
+            anchors.fill: parent
+            spacing: Units.dp(15)
+        }
+    }
+
+    Behavior on height {
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.InOutQuad
+        }
+    }
+}
+

--- a/src/qml/BrowserPage.qml
+++ b/src/qml/BrowserPage.qml
@@ -1,0 +1,150 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Item {
+    id: page
+
+    property alias webContainer: webContainer
+    property alias iconConnectionType: toolbar.iconConnectionType
+    property alias listView: tabBar.listView
+    property alias bookmarksBar: bookmarksBar
+    property alias bookmarkContainer: bookmarksBar.bookmarkContainer
+
+    function updateToolbar () {
+        toolbar.update()
+    }
+
+    property list<Action> overflowActions: [
+        Action {
+            name: qsTr("New window")
+            iconName: "action/open_in_new"
+            onTriggered: app.createWindow()
+        },
+        /*Action {
+            name: qsTr("Save page")
+            iconName: "content/save"
+        },
+        Action {
+            name: qsTr("Print page")
+            iconName: "action/print"
+        },*/
+        Action {
+            name: qsTr("History")
+            iconName: "action/history"
+            onTriggered: historyDrawer.open()
+        },
+        Action {
+            name: qsTr("Fullscreen")
+            iconName: "navigation/fullscreen"
+            onTriggered: {
+                // TODO: Why this if statement? Should the action be hidden in fullscreen?
+                // An action that doesn't do anything is confusing
+                if (!root.fullscreen)
+                    root.startFullscreenMode()
+            }
+        },
+        Action {
+            name: qsTr("Search")
+            iconName: "action/search"
+            onTriggered: root.showSearchOverlay()
+        },
+        Action {
+            name: qsTr("Bookmark")
+            visible: root.app.integratedAddressbars
+            iconName: "action/bookmark_border"
+            onTriggered: root.toggleActiveTabBookmark()
+        },
+        Action {
+            name: qsTr("Add to dash")
+            //visible: root.app.integratedAddressbars
+            iconName: "action/dashboard"
+            onTriggered: root.addToDash(activeTab.webview.url, activeTab.webview.title, activeTab.customColor)
+        },
+        Action {
+            name: qsTr("View source")
+            //visible: root.app.integratedAddressbars
+            iconName: "action/code"
+            onTriggered: activeTabViewSourceCode()
+        },
+        Action {
+            name: qsTr("Settings")
+            iconName: "action/settings"
+            onTriggered: settingsDrawer.open()
+        }
+    ]
+
+    View {
+        id: titlebar
+
+        width: parent.width
+        height: root.app.integratedAddressbars ? tabBar.height + bookmarksBar.height
+                                               : tabBar.height + toolbar.height + bookmarksBar.height
+
+        elevation: 2
+
+        BrowserTabBar { id: tabBar }
+
+        Item {
+            id: toolbarContainer
+            anchors.top: tabBar.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            Column {
+                anchors.fill: parent
+
+                BrowserToolbar { id: toolbar }
+
+                BookmarksBar { id: bookmarksBar }
+            }
+        }
+    }
+
+    FullscreenBar { id: fullscreenBar }
+
+    Item {
+        anchors {
+            top: fullscreen ? parent.top : titlebar.bottom
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+            topMargin: Units.dp(2)
+        }
+
+        Item {
+            id: webContainer
+            anchors.fill: parent
+        }
+    }
+
+    Dropdown {
+        id: overflowMenu
+        objectName: "overflowMenu"
+
+        width: Units.dp(250)
+        height: columnView.height + Units.dp(16)
+
+        ColumnLayout {
+            id: columnView
+            width: parent.width
+            anchors.centerIn: parent
+
+            Repeater {
+                model: overflowActions
+                delegate: ListItem.Standard {
+                    id: listItem
+                    text: modelData.name
+                    iconSource: modelData.iconSource
+                    onClicked: {
+                        overflowMenu.close()
+                        modelData.triggered(listItem)
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/qml/BrowserTabBar.qml
+++ b/src/qml/BrowserTabBar.qml
@@ -1,0 +1,148 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Rectangle {
+    id: tabBar
+
+    height: root.tabHeight
+    color: root.tabBackgroundColor
+
+    anchors {
+        left: parent.left
+        right: parent.right
+        top: parent.top
+    }
+
+    property alias listView: listView
+
+    ListView {
+        id: listView
+
+        anchors {
+            top: parent.top
+            bottom: parent.bottom
+            left: parent.left
+            right: toolbarIntegrated.left
+        }
+
+        orientation: ListView.Horizontal
+        spacing: Units.dp(1)
+        interactive: mouseArea.draggingId == -1
+
+        model: tabsModel
+
+        delegate: TabBarItemDelegate {}
+
+        MouseArea {
+            id: mouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+            property int index: listView.indexAt(mouseX + listView.contentX, mouseY)
+            property int draggingId: -1
+            property int activeIndex
+            propagateComposedEvents: true
+
+            onClicked: mouse.accepted = false;
+
+            onPressed: {
+                if (root.activeTabInEditMode) {
+                    mouse.accepted = false;
+                }
+            }
+
+            onPressAndHold: {
+                if (root.activeTabInEditMode) {
+                    mouse.accepted = false;
+                } else {
+                    var item = listView.itemAt(mouseX + listView.contentX, mouseY);
+                    if(item !== null) {
+                        draggingId = listView.model.get(activeIndex=index).uid;
+                    }
+                }
+
+            }
+            onReleased: {
+                if (activeTab.uid !== draggingId) {
+                    getTabModelDataByUID(draggingId).state = "inactive";
+                } else {
+                    getTabModelDataByUID(draggingId).state = "active";
+                }
+                draggingId = -1
+                mouse.accepted = false;
+            }
+            onPositionChanged: {
+                if (draggingId != -1 && index != -1 && index != activeIndex) {
+                    listView.model.move(activeIndex, activeIndex = index, 1);
+                }
+                mouse.accepted = false;
+
+            }
+            onDoubleClicked: {
+                mouse.accepted = false;
+            }
+
+            onWheel: {
+                listView.flick(wheel.angleDelta.y*10, 0);
+            }
+         }
+    }
+
+    View {
+        id: toolbarIntegrated
+        elevation: Units.dp(2)
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        width: root.app.integratedAddressbars ? btnAddTabIntegrated.width + btnDownloadsIntegrated.width +
+                                                btnMenuIntegrated.width + 3 * Units.dp(24)
+                                              : Units.dp(48)
+
+        IconButton {
+            id: btnAddTabIntegrated
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: btnDownloadsIntegrated.left
+            anchors.margins:if (root.app.integratedAddressbars) { Units.dp(24) } else { 12 }
+            color: root.iconColor
+            iconName: "content/add"
+
+            onClicked: addTab();
+        }
+
+        IconButton {
+            id: btnDownloadsIntegrated
+            visible: root.app.integratedAddressbars && downloadsDrawer.activeDownloads
+            width: root.app.integratedAddressbars && downloadsDrawer.activeDownloads ? Units.dp(24) : 0
+            color: downloadsDrawer.activeDownloads ? Theme.accentColor : root.iconColor
+            iconName: "file/file_download"
+            anchors.right: btnMenuIntegrated.left
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: root.app.integratedAddressbars && downloadsDrawer.activeDownloads ? Units.dp(24) : 0
+            onClicked: downloadsDrawer.open(btnDownloads)
+
+            Rectangle {
+                visible: downloadsDrawer.activeDownloads
+                z: -1
+                width: parent.width + Units.dp(5)
+                height: parent.height + Units.dp(5)
+                anchors.centerIn: parent
+                color: "white"
+                radius: width*0.5
+            }
+        }
+
+        IconButton {
+            id: btnMenuIntegrated
+            visible: root.app.integratedAddressbars
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: root.app.integratedAddressbars ? Units.dp(24) : 0
+            width: root.app.integratedAddressbars ? Units.dp(24) : 0
+            color: root.iconColor
+            iconName: "navigation/more_vert"
+            onClicked: overflowMenu.open(btnMenuIntegrated)
+        }
+    }
+}

--- a/src/qml/BrowserToolbar.qml
+++ b/src/qml/BrowserToolbar.qml
@@ -1,0 +1,102 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Rectangle {
+    id: toolbar
+
+    color: activeTab.customColor ? activeTab.customColor : root.tabColorActive
+    visible: !integratedAddressbars
+
+    height: Units.dp(64)
+    width: parent.width
+
+    property alias iconConnectionType: omnibox.iconConnectionType
+
+    function update() {
+        var url = activeTab.webview.url;
+
+        if (isBookmarked(url))
+            bookmarkButton.iconName = "action/bookmark";
+        else
+            bookmarkButton.iconName = "action/bookmark_border";
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: Units.dp(24)
+        anchors.rightMargin: Units.dp(24)
+
+        spacing: Units.dp(24)
+
+        Layout.alignment: Qt.AlignVCenter
+
+        IconButton {
+            iconName: "navigation/arrow_back"
+            enabled: root.activeTab.webview.canGoBack
+            onClicked: root.activeTab.webview.goBack()
+            color: root.currentIconColor
+        }
+
+        IconButton {
+            iconName: "navigation/arrow_forward"
+            enabled: root.activeTab.webview.canGoForward
+            onClicked: root.activeTab.webview.goForward()
+            color: root.currentIconColor
+        }
+
+        IconButton {
+            hoverAnimation: true
+            iconName: "navigation/refresh"
+            color: root.currentIconColor
+            visible: !activeTab.webview.loading
+            onClicked: activeTab.webview.reload()
+        }
+
+        LoadingIndicator {
+            visible: activeTab.webview.loading
+        }
+
+        Omnibox {
+            id: omnibox
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: parent.height - Units.dp(16)
+        }
+
+        IconButton {
+            id: bookmarkButton
+            color: root.currentIconColor
+            iconName: "action/bookmark_border"
+            onClicked: toggleActiveTabBookmark()
+        }
+
+        IconButton {
+            id: downloadsButton
+            color: downloadsDrawer.activeDownloads ? Theme.accentColor : root.currentIconColor
+            iconName: "file/file_download"
+            onClicked: downloadsDrawer.open(downloadsButton)
+
+            Rectangle {
+                visible: downloadsDrawer.activeDownloads
+                z: -1
+                width: parent.width + Units.dp(5)
+                height: parent.height + Units.dp(5)
+                anchors.centerIn: parent
+                color: "white"
+                radius: width*0.5
+            }
+        }
+
+        IconButton {
+            id: overflowButton
+            color: root.currentIconColor
+            iconName : "navigation/more_vert"
+            onClicked: overflowMenu.open(overflowButton)
+        }
+    }
+}
+
+

--- a/src/qml/FullscreenBar.qml
+++ b/src/qml/FullscreenBar.qml
@@ -1,0 +1,82 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Rectangle {
+    id: fullscreenBar
+
+    z: 5
+    visible: root.fullscreen
+    height: Units.dp(48)
+
+    anchors {
+        top: parent.top
+        left: parent.left
+        right: parent.right
+    }
+
+    Behavior on opacity {
+        NumberAnimation { duration: 300 }
+    }
+
+    Row {
+        anchors.fill: parent
+        anchors.leftMargin: Units.dp(24)
+        anchors.rightMargin: Units.dp(24)
+        spacing: Units.dp(24)
+
+        Image {
+            source: root.activeTab.webview.icon
+            width: Units.dp(18)
+            height: Units.dp(18)
+            anchors.verticalCenter: parent.verticalCenter
+
+        }
+
+        Text {
+            text: root.activeTab.webview.title
+            anchors.verticalCenter: parent.verticalCenter
+            font.family: root.fontFamily
+        }
+
+    }
+
+    IconButton {
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.right: parent.right
+        anchors.rightMargin: Units.dp(7)
+        iconName: "navigation/fullscreen_exit"
+        onClicked: {
+            root.endFullscreenMode();
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+        propagateComposedEvents: true
+
+        onEntered: {
+            parent.opacity = 1.0;
+        }
+
+        onExited: {
+            parent.opacity = 0.0;
+        }
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            var timer = Qt.createQmlObject("import QtQuick 2.0; Timer {}", parent);
+            timer.interval = 1500;
+            timer.repeat = false;
+            timer.triggered.connect(function () {
+                opacity = 0
+            });
+
+            timer.start();
+        }
+    }
+}

--- a/src/qml/Omnibox.qml
+++ b/src/qml/Omnibox.qml
@@ -1,0 +1,45 @@
+import QtQuick 2.4
+import Material 0.1
+import Material.ListItems 0.1 as ListItem
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 1.3 as Controls
+
+Rectangle {
+    radius: Units.dp(2)
+    color: root.addressBarColor
+    opacity: 0.5
+
+    property alias iconConnectionType: connectionTypeIcon
+
+    Icon {
+        id: connectionTypeIcon
+
+        name: root.activeTab.webview.secureConnection ? "action/lock" : "social/public"
+        color: root.activeTab.webview.secureConnection ? "green" : root.currentIconColor
+
+        anchors {
+            left: parent.left
+            verticalCenter: parent.verticalCenter
+            leftMargin: Units.dp(16)
+        }
+    }
+
+    TextField {
+        id: txtUrl
+
+        anchors {
+            left: connectionTypeIcon.right
+            right: parent.right
+            verticalCenter: parent.verticalCenter
+            leftMargin: Units.dp(16)
+            rightMargin: Units.dp(16)
+        }
+
+        showBorder: false
+        text: root.activeTab.webview.url
+        placeholderText: qsTr("Search or enter website name")
+        opacity: 1
+        textColor: root.tabTextColorActive
+        onAccepted: setActiveTabURL(text)
+    }
+}


### PR DESCRIPTION
**Changes**
 * Split the browser page out from the browser page and then refactor its various components (the tab bar, toolbar, bookmarks bar, etc.) into separate files so it's easier to find and work on the code. 
 * Simplify the toolbar layout by using a RowLayout (this makes it super easy to have the address bar fill the available space in the center)
 * Clean up some of the properties that were using if statements to use the [conditional operator](https://en.wikipedia.org/wiki/%3F:).

If you guys are happy with these changes, I'll plan on working on another pull request to refactor some of the imperative code into declarative code to fit more in line with the QML way of doing things.